### PR TITLE
set up InfluxDB and test otel-collector in local machine

### DIFF
--- a/expreiments/otelcDockerFile/Dockerfile
+++ b/expreiments/otelcDockerFile/Dockerfile
@@ -1,0 +1,20 @@
+# Use a lightweight base image
+FROM ubuntu:22.04
+
+# Set working directory
+WORKDIR /app
+
+# Copy the otelcol-contrib binary from your local system
+COPY otelcol-contrib /app/otelcol-contrib
+
+# Copy the config file
+COPY services/otel-collector-config.yaml /etc/otelcol-contrib/config.yaml
+
+# Ensure the binary is executable
+RUN chmod +x /app/otelcol-contrib
+
+# Expose ports from your config (and extras from your Docker command)
+EXPOSE 4317 4318 13133 1777 55679 9090 8889
+
+# Set the entrypoint to run the collector with the config
+ENTRYPOINT ["/app/otelcol-contrib", "--config", "/etc/otelcol-contrib/config.yaml"]

--- a/expreiments/readme.md
+++ b/expreiments/readme.md
@@ -1,0 +1,81 @@
+
+# Set up influxdb
+
+## 1. create the docker images
+    docker pull mcr.microsoft.com/azurelinux/base/influxdb:2.7
+
+REPOSITORY                                     TAG               IMAGE ID       CREATED         SIZE
+my-otel-collector                              0.120.0           0029d73ca208  2 minutes ago   514MB
+curlimages/curl                                latest            94e9e444bcba   2 weeks ago     41.7MB
+mcr.microsoft.com/azurelinux/base/influxdb     2.7               a62c74c4ea47   3 weeks ago     421MB
+otel-grpc-demo                                 latest            99125ba4a79d   4 months ago    20MB
+otel/opentelemetry-collector-contrib           latest            85ac41c2db88   12 days ago     397MB
+otel/opentelemetry-collector                   latest            fae9574bf0ec   4 months ago    143MB
+
+## 2. Start otel-collector and influxDB on the same network
+
+    docker network create monitoring
+    docker run --network monitoring --name influxdb -p 8086:8086 a62c74c4ea47
+
+    docker run --network monitoring --name otel-collector \
+    -p 9090:9090 -p 8889:8889 -p 4317:4317 -p 4318:4318 \
+    -v $(pwd)/services/otel-collector-config.yaml:/etc/otelcol-contrib/config.yaml \
+    0029d73ca208
+
+## 3. Set up user/password/token in influxDB
+    docker exec -it influxdb /bin/bash
+    influx setup
+    influx auth list
+
+    docker images
+
+
+## 4. Set up the environment variables
+
+    export INFLUX_TOKEN="9I3G2EyKnW4bEHwkV3Y7-dfubQD2VnXQ5x6PGMG47lQQsIAw8R0zf85-p15DOy1m-ZAIwOnODn3iwOeGuLcHqQ=="
+    export INFLUX_ORG="pncm"
+    export INFLUX_BUCKET="bucket1"
+    export INFLUX_URL="http://localhost:8086"
+
+## 5. Test the setup
+    TIMESTAMP=$(date +%s)
+    curl -XPOST "$INFLUX_URL/api/v2/write?org=$INFLUX_ORG&bucket=$INFLUX_BUCKET&precision=s"   --header "Authorization: Token $INFLUX_TOKEN"   --header "Content-Type: text/plain"   --data-binary "temperature,location=room1 value=223.5 $TIMESTAMP"
+
+    TIMESTAMP=$(date +%s)
+    echo "temperature,location=room1 value=23.5 $TIMESTAMP" | influx write \
+    --org "$INFLUX_ORG" \
+    --bucket "$INFLUX_BUCKET" \
+    --precision s \
+    --token "$INFLUX_TOKEN" \
+    --host "$INFLUX_URL" \
+    --format lp
+
+    TIMESTAMP=$(date +%s)
+    curl -XPOST "$INFLUX_URL/api/v2/write?org=$INFLUX_ORG&bucket=$INFLUX_BUCKET&precision=s" \
+    --header "Authorization: Token $INFLUX_TOKEN" \
+    --header "Content-Type: text/plain" \
+    --data-binary "temperature,location=room1 value=123.5 $TIMESTAMP"
+
+    curl -X POST http://localhost:8086/api/v2/query?org=pncm --data '{"query": "buckets()"}' --header "Authorization: Token $INFLUX_TOKEN" 
+    curl -X POST http://localhost:8086/api/v2/query?org=pncm -d 'from(bucket: "bucket1") |> range(start: -1h)' --header "Authorization: Token $INFLUX_TOKEN"  --header "Content-Type: application/vnd.flux"
+
+    curl -XPOST "http://localhost:8086/api/v2/query?org=pncm"  -H "Authorization: Token $INFLUX_TOKEN"  -d '{"query": "from(bucket:\"bucket1\") |> range(start: -10h)"}'
+
+    curl -curl -X POST http://localhost:8086/api/v2/query?org=pncm  -H "Authorization: Token $INFLUX_TOKEN"   --data '{ "query": "from(bucket: \"bucket1\") |> range(start: -10h)"}'
+
+##	6. Send metric to otel-collector
+    docker run --rm --network monitoring -v $(pwd)/send_metric.py:/app/send_metric.py python:3.11 bash -c "pip install opentelemetry-proto==1.30.0 requests && python /app/send_metric.py"
+
+//1.28 is more stable version, 1.30 is the latest version
+
+    docker run --rm --network monitoring -v $(pwd)/send_metric.py:/app/send_metric.py python:3.11 bash -c "pip install opentelemetry-api==1.28.0 opentelemetry-sdk==1.28.0 opentelemetry-exporter-otlp-proto-http==1.28.0 opentelemetry-proto==1.28.0 requests  && python /app/send_metric.py"
+
+##	7. Typical troubleshoot commands
+    docker stats
+    docker logs influxdb
+    docker logs otel-collector
+    docker inspect influxdb
+    docker inspect otel-collector
+    docker ps -a
+    netstat -tulnp | grep 8889
+

--- a/expreiments/send_metric.py
+++ b/expreiments/send_metric.py
@@ -1,0 +1,48 @@
+import logging
+import time
+from google.protobuf.json_format import MessageToJson
+from opentelemetry import metrics
+from opentelemetry.sdk.metrics import MeterProvider
+from opentelemetry.sdk.metrics.export import PeriodicExportingMetricReader
+from opentelemetry.exporter.otlp.proto.http.metric_exporter import OTLPMetricExporter
+from opentelemetry.sdk.resources import SERVICE_NAME, Resource
+from opentelemetry.proto.metrics.v1.metrics_pb2 import MetricsData  # Import protobuf type
+
+# Configure logging
+logging.basicConfig(level=logging.DEBUG)
+
+# Custom metric exporter with logging
+class LoggingOTLPMetricExporter(OTLPMetricExporter):
+    def export(self, metrics_data, **kwargs):
+        if isinstance(metrics_data, MetricsData):  # Ensure it's a protobuf message
+            serialized_data = MessageToJson(metrics_data)  # Convert to JSON
+            logging.debug(f"Exporting metrics: {serialized_data}")
+        else:
+            logging.debug("Received non-protobuf metrics data")
+            logging.debug(f"Raw metrics data type: {type(metrics_data)}")
+
+            try:
+                # OpenTelemetry does not directly provide a .to_protobuf() method
+                # Instead, we rely on OpenTelemetry's exporter behavior
+                serialized_data = str(metrics_data)  # Fallback: Convert to string representation
+                logging.debug(f"Exporting metrics: {serialized_data}")
+            except Exception as e:
+                logging.error(f"Failed to serialize metrics data: {e}")
+
+        
+        return super().export(metrics_data, **kwargs)
+
+# Setup OpenTelemetry metric provider
+resource = Resource(attributes={SERVICE_NAME: "test-service"})
+exporter = LoggingOTLPMetricExporter(endpoint="http://otel-collector:4318/v1/metrics")
+reader = PeriodicExportingMetricReader(exporter)
+provider = MeterProvider(resource=resource, metric_readers=[reader])
+metrics.set_meter_provider(provider)
+
+# Create and set gauge metric
+meter = metrics.get_meter("test-meter")
+gauge = meter.create_gauge("test_metric", description="A test metric", unit="1")
+gauge.set(42)
+
+# Allow time for metric export
+time.sleep(5)

--- a/services/otel-collector-config.yaml
+++ b/services/otel-collector-config.yaml
@@ -2,22 +2,23 @@ receivers:
   otlp:
     protocols:
       grpc:
-        endpoint: "0.0.0.0:4317"  # Ensure OTel listens on this port
+        endpoint: "0.0.0.0:4317"
       http:
-        endpoint: "0.0.0.0:4318"  # (Optional) HTTP OTLP
+        endpoint: "0.0.0.0:4318"  # Removed debug: true
 
 exporters:
   influxdb:
-    endpoint: "http://influxdb:8086"  # Use the InfluxDB container name on the same Docker network
+    endpoint: "http://influxdb:8086"
     org: "pncm"
     bucket: "bucket1"
     token: "9I3G2EyKnW4bEHwkV3Y7-dfubQD2VnXQ5x6PGMG47lQQsIAw8R0zf85-p15DOy1m-ZAIwOnODn3iwOeGuLcHqQ=="
-
   debug:
     verbosity: detailed
 
 processors:
   batch:
+    timeout: 1s
+    send_batch_size: 10
 
 extensions:
   health_check:
@@ -28,10 +29,20 @@ extensions:
     endpoint: ":55679"
 
 service:
+  telemetry:
+    logs:
+      level: "debug"
   extensions: [health_check, pprof, zpages]
-
   pipelines:
     metrics:
       receivers: [otlp]
       processors: [batch]
-      exporters: [debug,influxdb]
+      exporters: [debug, influxdb]
+    logs:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [influxdb, debug]
+    traces:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [debug, influxdb]

--- a/services/otel-collector-config.yaml
+++ b/services/otel-collector-config.yaml
@@ -2,15 +2,16 @@ receivers:
   otlp:
     protocols:
       grpc:
-        endpoint: 0.0.0.0:4317
+        endpoint: "0.0.0.0:4317"  # Ensure OTel listens on this port
+      http:
+        endpoint: "0.0.0.0:4318"  # (Optional) HTTP OTLP
 
 exporters:
-  prometheus:
-    endpoint: "0.0.0.0:8889"
-    const_labels:
-      "os_name": "demo-os"
-      "os_type": "demo-os"
-      "os_version": "202411.0"
+  influxdb:
+    endpoint: "http://influxdb:8086"  # Use the InfluxDB container name on the same Docker network
+    org: "pncm"
+    bucket: "bucket1"
+    token: "9I3G2EyKnW4bEHwkV3Y7-dfubQD2VnXQ5x6PGMG47lQQsIAw8R0zf85-p15DOy1m-ZAIwOnODn3iwOeGuLcHqQ=="
 
   debug:
     verbosity: detailed
@@ -18,9 +19,19 @@ exporters:
 processors:
   batch:
 
+extensions:
+  health_check:
+    endpoint: ":13133"
+  pprof:
+    endpoint: ":1777"
+  zpages:
+    endpoint: ":55679"
+
 service:
+  extensions: [health_check, pprof, zpages]
+
   pipelines:
     metrics:
       receivers: [otlp]
       processors: [batch]
-      exporters: [debug, prometheus]
+      exporters: [debug,influxdb]


### PR DESCRIPTION
	1. Set up influxdb
docker pull mcr.microsoft.com/azurelinux/base/influxdb:2.7
	2. Start otel-collector and influxDB on the same network
docker network create monitoring
docker run --network monitoring --name influxdb -p 8086:8086 a62c74c4ea47

docker run --network monitoring --name otel-collector \
  -p 9090:9090 -p 8889:8889 -p 4317:4317 -p 4318:4318 \
  -v $(pwd)/services/otel-collector-config.yaml:/etc/otelcol-contrib/config.yaml \
  0029d73ca208

	3. Set up user/password/token
docker exec -it influxdb /bin/bash
influx setup
influx auth list

docker images
REPOSITORY                                     TAG               IMAGE ID       CREATED         SIZE
my-otel-collector                              0.120.0           0029d73ca208  2 minutes ago   514MB
curlimages/curl                                latest            94e9e444bcba   2 weeks ago     41.7MB
mcr.microsoft.com/azurelinux/base/influxdb     2.7               a62c74c4ea47   3 weeks ago     421MB
otel-grpc-demo                                 latest            99125ba4a79d   4 months ago    20MB

otel/opentelemetry-collector-contrib           latest            85ac41c2db88   12 days ago     397MB
otel/opentelemetry-collector                   latest            fae9574bf0ec   4 months ago    143MB

	4. Set up the environment variables

export INFLUX_TOKEN="9I3G2EyKnW4bEHwkV3Y7-dfubQD2VnXQ5x6PGMG47lQQsIAw8R0zf85-p15DOy1m-ZAIwOnODn3iwOeGuLcHqQ=="
export INFLUX_ORG="pncm"
export INFLUX_BUCKET="bucket1"
export INFLUX_URL="http://localhost:8086"

	5. Test the setup
TIMESTAMP=$(date +%s)
 curl -XPOST "$INFLUX_URL/api/v2/write?org=$INFLUX_ORG&bucket=$INFLUX_BUCKET&precision=s"   --header "Authorization: Token $INFLUX_TOKEN"   --header "Content-Type: text/plain"   --data-binary "temperature,location=room1 value=223.5 $TIMESTAMP"

TIMESTAMP=$(date +%s)
echo "temperature,location=room1 value=23.5 $TIMESTAMP" | influx write \
  --org "$INFLUX_ORG" \
  --bucket "$INFLUX_BUCKET" \
  --precision s \
  --token "$INFLUX_TOKEN" \
  --host "$INFLUX_URL" \
  --format lp

TIMESTAMP=$(date +%s)
curl -XPOST "$INFLUX_URL/api/v2/write?org=$INFLUX_ORG&bucket=$INFLUX_BUCKET&precision=s" \
  --header "Authorization: Token $INFLUX_TOKEN" \
  --header "Content-Type: text/plain" \
  --data-binary "temperature,location=room1 value=123.5 $TIMESTAMP"

curl -X POST http://localhost:8086/api/v2/query?org=pncm --data '{"query": "buckets()"}' --header "Authorization: Token $INFLUX_TOKEN" 
curl -X POST http://localhost:8086/api/v2/query?org=pncm -d 'from(bucket: "bucket1") |> range(start: -1h)' --header "Authorization: Token $INFLUX_TOKEN"  --header "Content-Type: application/vnd.flux"

curl -XPOST "http://localhost:8086/api/v2/query?org=pncm"  -H "Authorization: Token $INFLUX_TOKEN"  -d '{"query": "from(bucket:\"bucket1\") |> range(start: -10h)"}'

curl -curl -X POST http://localhost:8086/api/v2/query?org=pncm  -H "Authorization: Token $INFLUX_TOKEN"   --data '{ "query": "from(bucket: \"bucket1\") |> range(start: -10h)"}'

	6. Send metric to otel-collector
docker run --rm --network monitoring -v $(pwd)/send_metric.py:/app/send_metric.py python:3.11 bash -c "pip install opentelemetry-proto==1.30.0 requests && python /app/send_metric.py"

//1.28 is more stable version, 1.30 is the latest version

docker run --rm --network monitoring -v $(pwd)/send_metric.py:/app/send_metric.py python:3.11 bash -c "pip install opentelemetry-api==1.28.0 opentelemetry-sdk==1.28.0 opentelemetry-exporter-otlp-proto-http==1.28.0 opentelemetry-proto==1.28.0 requests  && python /app/send_metric.py"

	7. Typical troubleshoot commands
docker stats
docker logs influxdb
docker logs otel-collector
docker inspect influxdb
docker inspect otel-collector
docker ps -a
netstat -tulnp | grep 8889

